### PR TITLE
fix(module): export default plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ npm install -D cem-plugin-better-lit-types
 ```
 Create or add to existing `custom-elements-manifest.config.mjs` following lines:
 ```javascript
-import BetterTypesPlugin from 'cem-plugin-better-lit-types';
+import BetterLitTypesPlugin from 'cem-plugin-better-lit-types';
 
 export default {
-  plugins: [BetterTypesPlugin]
+  plugins: [BetterLitTypesPlugin]
 }
 ```
 <br />

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './plugin'
 export * from './storybook'
+export { plugin as default } from './plugin'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from './plugin'
 export * from './storybook'
-export { plugin as default } from './plugin'
+export { betterLitTypes as default } from './plugin'

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -83,7 +83,7 @@ const createGenerator = (manifest: any) => {
 /**
  * Creates better types for LitElement
  */
-export default {
+export const plugin = {
   name: 'BETTER TYPES',
   packageLinkPhase({ customElementsManifest }: { customElementsManifest: any }) {
     const generator = createGenerator(customElementsManifest)

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -83,7 +83,7 @@ const createGenerator = (manifest: any) => {
 /**
  * Creates better types for LitElement
  */
-export const plugin = {
+export const betterLitTypes = {
   name: 'BETTER TYPES',
   packageLinkPhase({ customElementsManifest }: { customElementsManifest: any }) {
     const generator = createGenerator(customElementsManifest)


### PR DESCRIPTION
### Description
Seems like the reexport of the default export can't be correctly handled.
In this PR we export `{ plugin }` from `./plugin` and ` plugin as default` from the index

closes: #1 